### PR TITLE
added cors support to allow queries across services

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,5 @@ WORKDIR /tetra/
 ADD setup.py tetra.conf tetra-test.conf ./
 ADD tetra tetra/
 RUN pip install .
-RUN pip install gunicorn
+RUN pip install gunicorn falcon_cors
 RUN adduser --disabled-password --gecos '' tetra-worker

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ celery==4.2.0
 debtcollector==1.19.0
 enum34==1.1.6
 falcon==1.4.1
+falcon_cors==1.1.7
 funcsigs==1.0.2
 kombu==4.2.1
 netaddr==0.7.19

--- a/tetra/app.py
+++ b/tetra/app.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 import falcon
 import json
+from falcon_cors import CORS
 
 from api.resources import (
     BuildResource,
@@ -48,6 +49,9 @@ class VersionResource(object):
         resp.body = json.dumps(version)
 
 
+cors = CORS(allow_all_origins=True)
+
+
 class TetraAPI(falcon.API):
 
     RESOURCES = [
@@ -65,7 +69,7 @@ class TetraAPI(falcon.API):
     ]
 
     def __init__(self):
-        super(TetraAPI, self).__init__()
+        super(TetraAPI, self).__init__(middleware=[cors.middleware])
         for resource in self.RESOURCES:
             self.add_route(resource.ROUTE, resource)
 


### PR DESCRIPTION
this is helpful during development, but should be handled by a reverse proxy at some point

apparently the `requirements.txt` are not yet honoured in the dockerfile and I wasn't quite sure what the intention was with `dev-requirements`, `requirements` and the `install_requires` list in `setup.py` - so it's for now installed with the pip hammer in the `Dockerfile`. That will need some reworking on another day, independent of this change-set (just like the reverse proxy/ api-gateway).

Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>