### PR TITLE
Feature/api gateway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,5 @@ WORKDIR /tetra/
 ADD setup.py tetra.conf tetra-test.conf ./
 ADD tetra tetra/
 RUN pip install .
-RUN pip install gunicorn falcon_cors
+RUN pip install gunicorn
 RUN adduser --disabled-password --gecos '' tetra-worker

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ docker-build:
 	docker-compose -f docker-compose.yml -f development.yml build
 
 docker-dev:
-	docker-compose -f docker-compose.yml -f development.yml up -d api worker ui
+	docker-compose -f docker-compose.yml -f development.yml up -d
 
 docker-deploy-production:
 	docker-compose -f docker-compose.yml -f production.yml up -d

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The tests look for a `tetra-test.conf` file. The complete list of options is in
 `tests/config.py`. Here's an example `tetra-test.conf` file:
 
     [api]
-    base_url = http://localhost:7374
+    base_url = http://localhost/api
 
 The you can either use `tox` to run the tests:
 

--- a/development.yml
+++ b/development.yml
@@ -1,9 +1,11 @@
 version: '2'
 services:
   api:
+    build: .
     volumes:
       - .:/tetra
   worker:
+    build: .
     volumes:
       - .:/tetra
   ui:
@@ -14,3 +16,15 @@ services:
       - ./ui/:/work
       - /work/node_modules
       - /work/dist
+  gateway:
+    # Enables the web UI and tells Traefik to listen to docker
+    command: 
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+      - "--api.insecure=true"
+      - "--log.filePath=`/home/traefik.log`"
+      - "--accesslog=true"
+    ports:
+      # The Web UI (enabled by --api.insecure=true)
+      - "8888:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,24 @@
 version: '2'
 services:
   api:
-    build: .
     image: tetra-api
     container_name: tetra-api
-    ports:
-      - "7374:7374"
     depends_on:
       - db
     links:
       - db
     command: |
       bash -c "export PYTHONUNBUFFERED=1 && gunicorn --reload -t 120 --bind 0.0.0.0:7374 --access-logfile - tetra.app:application"
+    labels:
+      - "traefik.enable=true"
+      # password hashed according to https://docs.traefik.io/middlewares/basicauth/#general
+      # so: `htpasswd -nb -B <username> <password>` and escaped `$` signs (as `$$`)
+      - "traefik.http.middlewares.auth.basicauth.users=test:$$apr1$$H6uskkkW$$IgXLP6ewTrSuBkTrqE8wj/"
+      - "traefik.http.middlewares.api-stripprefix.stripprefix.prefixes=/api/"
+      - "traefik.http.routers.backend.entrypoints=web"
+      - "traefik.http.routers.backend.rule=PathPrefix(`/api/`)"
+      - "traefik.http.routers.backend.middlewares=api-stripprefix,auth"
+      - "traefik.http.services.backend.loadbalancer.server.port=7374"
   worker:
     image: tetra-api
     container_name: tetra-worker
@@ -42,11 +49,30 @@ services:
       RABBITMQ_DEFAULT_USER: tetra
       RABBITMQ_DEFAULT_PASS: password
   ui:
-    build:
-      context: ./ui
     image: tetra-ui
     container_name: tetra-ui
-    ports:
-      - "7375:7375"
     depends_on:
+      - api
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.frontend.entrypoints=web"
+      - "traefik.http.routers.frontend.rule=PathPrefix(`/`)"
+      - "traefik.http.routers.frontend.middlewares=auth"
+      - "traefik.http.services.frontend.loadbalancer.server.port=80"
+
+  gateway:
+    image: traefik:v2.0
+    # Enables the web UI and tells Traefik to listen to docker
+    command: 
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+    ports:
+      # The HTTP port
+      - "80:80"
+    volumes:
+      # So that Traefik can listen to the Docker events
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+    depends_on:
+      - ui
       - api

--- a/etc/tetra/tetra-test.conf.sample
+++ b/etc/tetra/tetra-test.conf.sample
@@ -1,2 +1,2 @@
 [api]
-base_url = http://localhost:7374
+base_url = http://localhost/api

--- a/production.yml
+++ b/production.yml
@@ -2,6 +2,8 @@ version: '2'
 services:
   api:
     restart: always
+    label:
+      - "traefik.http.middlewares.auth.basicauth.users=$TETRA_USERNAME:$TETRA_PASSWORD"
   worker:
     restart: always
   queue:
@@ -9,4 +11,6 @@ services:
   db:
     restart: always
   ui:
+    restart: always
+  gateway:
     restart: always

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ celery==4.2.0
 debtcollector==1.19.0
 enum34==1.1.6
 falcon==1.4.1
-falcon_cors==1.1.7
 funcsigs==1.0.2
 kombu==4.2.1
 netaddr==0.7.19

--- a/tetra/app.py
+++ b/tetra/app.py
@@ -47,6 +47,7 @@ class VersionResource(object):
                 }
         resp.body = json.dumps(version)
 
+
 class TetraAPI(falcon.API):
 
     RESOURCES = [

--- a/tetra/app.py
+++ b/tetra/app.py
@@ -15,7 +15,6 @@ limitations under the License.
 """
 import falcon
 import json
-from falcon_cors import CORS
 
 from api.resources import (
     BuildResource,
@@ -48,10 +47,6 @@ class VersionResource(object):
                 }
         resp.body = json.dumps(version)
 
-
-cors = CORS(allow_all_origins=True)
-
-
 class TetraAPI(falcon.API):
 
     RESOURCES = [
@@ -69,7 +64,7 @@ class TetraAPI(falcon.API):
     ]
 
     def __init__(self):
-        super(TetraAPI, self).__init__(middleware=[cors.middleware])
+        super(TetraAPI, self).__init__()
         for resource in self.RESOURCES:
             self.add_route(resource.ROUTE, resource)
 

--- a/travis-setup.sh
+++ b/travis-setup.sh
@@ -19,7 +19,7 @@ EOF
 
 cat <<EOF > tetra-test.conf
 [api]
-base_url = http://localhost:7374
+base_url = http://test:test@localhost/api
 EOF
 
 if [ "$TOXENV" = "functional" ]; then

--- a/ui/app/projects-view.jsx
+++ b/ui/app/projects-view.jsx
@@ -7,7 +7,7 @@ class ProjectsView extends React.Component {
     };
 
     componentDidMount() {
-        this.projectsRequest = fetch('http://localhost:7374/projects', result => {
+        this.projectsRequest = fetch('/api/projects', result => {
             this.setState({
                 projects: result
             });

--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -2,11 +2,6 @@ server {
     listen 7375 default_server;
     listen [::]:7375 default_server;
 
-    location /api/ {
-        # "api" is the docker-compose service running the tetra api
-        proxy_pass          http://api:7374/;
-    }
-
     location / {
         root /usr/share/nginx/html/;
         try_files $uri /index.html;

--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -10,7 +10,7 @@ module.exports = {
     },
     devServer: {
         inline: true,
-        port: 7375,
+        port: 80,
         host: '0.0.0.0'
     },
     module: {


### PR DESCRIPTION
this removes the requirement for cors on the backend server + adds a reverse proxy (traefik) instead, that  adds basic auth for both routes (ui + api) and has `test:test` set as the default username/ password combination...
just in case this is deployed somewhere, the routing could be changed or automatic lets encrypt certificates added 🙂

to start the project you can continue to use `make docker-dev`