### PR TITLE
offloaded production traefik to external instance

### DIFF
--- a/development.yml
+++ b/development.yml
@@ -4,6 +4,17 @@ services:
     build: .
     volumes:
       - .:/tetra
+    labels:
+      # password hashed according to https://docs.traefik.io/middlewares/basicauth/#general
+      # so: `htpasswd -nb -B <username> <password>` and escaped `$` signs (as `$$`)
+      # here username:password are test:test
+      - "traefik.http.middlewares.auth.basicauth.users=test:$$apr1$$H6uskkkW$$IgXLP6ewTrSuBkTrqE8wj/"
+      - "traefik.http.routers.tetra-api.rule=PathPrefix(`/api/`)"
+      - "traefik.http.routers.tetra-api.middlewares=api-stripprefix,auth"
+      - "traefik.http.routers.tetra-automation-api.rule=PathPrefix(`/api/projects/{project_id}/builds/{build_id}/results`)"
+      # here username:password are test:different
+      - "traefik.http.middlewares.bauth.basicauth.users=test:$$2y$$05$$bJOpgyk0WkRrqHu0wBPB/eX9W.NSqxFV/CtmEaZ8eWwEzup7Knq8."
+      - "traefik.http.routers.tetra-automation-api.middlewares=api-stripprefix,bauth"
   worker:
     build: .
     volumes:
@@ -13,20 +24,31 @@ services:
       context: ./ui
       dockerfile: Dockerfile.dev
     labels:
-        - "traefik.http.services.frontend.loadbalancer.server.port=80"
+      - "traefik.http.routers.tetra-ui.rule=PathPrefix(`/`)"
+      - "traefik.http.routers.tetra-ui.middlewares=auth"
     volumes:
       - ./ui/:/work
       - /work/node_modules
       - /work/dist
   gateway:
+    image: traefik:v2.1
+    container_name: tetra-gateway
     # Enables the web UI and tells Traefik to listen to docker
     command:
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
-      - "--entrypoints.web.address=:80"
+      - "--entrypoints.http.address=:80"
       - "--api.insecure=true"
       - "--log.filePath=`/home/traefik.log`"
       - "--accesslog=true"
     ports:
+      # The HTTP port
+      - "80:80"
       # The Web UI (enabled by --api.insecure=true)
-      - "8888:8080"
+      - "8080:8080"
+    volumes:
+      # So that Traefik can listen to the Docker events
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+    depends_on:
+      - ui
+      - api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,14 +11,11 @@ services:
       bash -c "export PYTHONUNBUFFERED=1 && gunicorn --reload -t 120 --bind 0.0.0.0:7374 --access-logfile - tetra.app:application"
     labels:
       - "traefik.enable=true"
-      # password hashed according to https://docs.traefik.io/middlewares/basicauth/#general
-      # so: `htpasswd -nb -B <username> <password>` and escaped `$` signs (as `$$`)
-      - "traefik.http.middlewares.auth.basicauth.users=test:$$apr1$$H6uskkkW$$IgXLP6ewTrSuBkTrqE8wj/"
       - "traefik.http.middlewares.api-stripprefix.stripprefix.prefixes=/api/"
-      - "traefik.http.routers.backend.entrypoints=web"
-      - "traefik.http.routers.backend.rule=PathPrefix(`/api/`)"
-      - "traefik.http.routers.backend.middlewares=api-stripprefix,auth"
-      - "traefik.http.services.backend.loadbalancer.server.port=7374"
+      - "traefik.http.routers.tetra-api.entrypoints=http"
+      - "traefik.http.routers.tetra-api.rule=Host(`qastatus.mender.io`) && PathPrefix(`/api/`)"
+      - "traefik.http.routers.tetra-api.middlewares=api-stripprefix,oauth"
+      - "traefik.http.services.tetra-api.loadbalancer.server.port=7374"
   worker:
     image: tetra-api
     container_name: tetra-worker
@@ -55,23 +52,9 @@ services:
       - api
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.frontend.entrypoints=web"
-      - "traefik.http.routers.frontend.rule=PathPrefix(`/`)"
-      - "traefik.http.routers.frontend.middlewares=auth"
+      - "traefik.http.routers.tetra-ui.entrypoints=http"
+      - "traefik.http.routers.tetra-ui.rule=Host(`qastatus.mender.io`)"
+      - "traefik.http.routers.tetra-ui.middlewares=oauth"
+      - "traefik.http.services.tetra-ui.loadbalancer.server.port=80"
   gateway:
-    image: traefik:v2.0
-    container_name: tetra-gateway
-    # Enables the web UI and tells Traefik to listen to docker
-    command:
-      - "--providers.docker=true"
-      - "--providers.docker.exposedbydefault=false"
-      - "--entrypoints.web.address=:80"
-    ports:
-      # The HTTP port
-      - "80:80"
-    volumes:
-      # So that Traefik can listen to the Docker events
-      - "/var/run/docker.sock:/var/run/docker.sock:ro"
-    depends_on:
-      - ui
-      - api
+    image: busybox

--- a/production.yml
+++ b/production.yml
@@ -4,7 +4,11 @@ services:
     build: .
     restart: always
     labels:
-      - "traefik.http.middlewares.auth.basicauth.users=$TETRA_USERNAME:$TETRA_PASSWORD"
+      # password hashed according to https://docs.traefik.io/middlewares/basicauth/#general
+      # so: `htpasswd -nb -B <username> <password>` and escaped `$` signs (as `$$`)
+      - "traefik.http.routers.tetra-automation-api.rule=PathPrefix(`/api/projects/{project_id}/builds/{build_id}/results`)"
+      - "traefik.http.middlewares.basicauth.basicauth.users=$TETRA_USERNAME:$TETRA_PASSWORD"
+      - "traefik.http.routers.tetra-automation-api.middlewares=api-stripprefix,basicauth"
   worker:
     build: .
     restart: always
@@ -15,8 +19,4 @@ services:
   ui:
     build:
       context: ./ui
-    restart: always
-    labels:
-      - "traefik.http.services.frontend.loadbalancer.server.port=80"
-  gateway:
     restart: always


### PR DESCRIPTION
This is to allow a shared traefik instance to proxy multiple services.
During development the authentication will be overwritten in the development file
and it will only be extended with an extra basicauth in production.
This is done to allow pushes from pipelines as alternative to non-interactive oauth
while skipping the requirement for oauth on localhost (fallback to basicauth here)

Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>